### PR TITLE
Draft abstract token standard and implementation

### DIFF
--- a/contracts/claim/abstract/PriceTierVesting.sol
+++ b/contracts/claim/abstract/PriceTierVesting.sol
@@ -29,7 +29,7 @@ abstract contract PriceTierVesting is AdvancedDistributor, IPriceTierVesting {
 		(
 			uint80 roundID,
 			int256 _price,
-			uint256 startedAt,
+			, // uint256 startedAt
 			uint256 timeStamp,
 			uint80 answeredInRound
 		) = oracle.latestRoundData();

--- a/contracts/sale/v2/FlatPriceSale.sol
+++ b/contracts/sale/v2/FlatPriceSale.sol
@@ -331,7 +331,7 @@ contract FlatPriceSale is Sale, PullPaymentUpgradeable {
 		(
 			uint80 roundID,
 			int256 _price,
-			uint256 startedAt,
+			, // uint256 startedAt
 			uint256 timeStamp,
 			uint80 answeredInRound
 		) = oracle.latestRoundData();


### PR DESCRIPTION
The abstract token standard lets participants move tokens on- and off-chain as desired, enabling high-volume, zero-cost mints while preserving on-chain composability.

Abstract tokens provide a standard interface on EVM blockchains to:
* Mint tokens off-chain as messages
* Reify tokens on-chain via smart contract
* De-reify tokens back into messages

Abstract tokens can comply with existing standards like ERC20, ERC721, and ERC1155, and are especially suited for token applications like airdrops, receipts, credentials, and a new form of bridging.