### PR TITLE
Sherlock 130

### DIFF
--- a/contracts/claim/Satellite.sol
+++ b/contracts/claim/Satellite.sol
@@ -92,7 +92,7 @@ contract Satellite is MerkleSet {
       address(0), // delegate, only required for self-execution + slippage
       0, // total
       0, // slippage
-      abi.encodePacked(msg.sender, _domain, total, proof) // data
+      abi.encode(msg.sender, _domain, total, proof) // data
     );
 
     // Emit event

--- a/contracts/mocks/ConnextMock.sol
+++ b/contracts/mocks/ConnextMock.sol
@@ -55,7 +55,8 @@ contract ConnextMock {
         address _originSender,
         uint32 _origin,
         bytes32[] memory _proof,
-        address _distributor) public returns (bytes memory) {
+        address _distributor
+    ) public returns (bytes memory) {
 
         return IXReceiver(_distributor).xReceive(
             _transferId,


### PR DESCRIPTION
Fixes https://github.com/sherlock-audit/2023-06-tokensoft-judging/issues/130

Note: No tests are updated because [`ConnextMock`](https://github.com/SoftDAO/contracts/blob/291df55ddb0dbf53c6ed4d5b7432db0c357ca4d3/contracts/mocks/ConnextMock.sol#L66) was properly encoding while [`Satellite`](https://github.com/SoftDAO/contracts/blob/291df55ddb0dbf53c6ed4d5b7432db0c357ca4d3/contracts/claim/Satellite.sol#L95) was not