### PR TITLE
Sherlock 143

### DIFF
--- a/contracts/claim/abstract/CrosschainDistributor.sol
+++ b/contracts/claim/abstract/CrosschainDistributor.sol
@@ -61,6 +61,7 @@ abstract contract CrosschainDistributor is AdvancedDistributor, ICrosschain {
   /**
    * @notice Settles claimed tokens to any valid Connext domain.
    * @dev permissions are not checked: call only after a valid claim is executed
+   * @dev assumes connext fees are paid in native assets, not from the claim total
    * @param _recipient: the address that will receive tokens
    * @param _recipientDomain: the domain of the address that will receive tokens
    * @param _amount: the amount of claims to settle
@@ -75,7 +76,7 @@ abstract contract CrosschainDistributor is AdvancedDistributor, ICrosschain {
     if (_recipientDomain == 0 || _recipientDomain == domain) {
       token.safeTransfer(_recipient, _amount);
     } else {
-      id = connext.xcall(
+      id = connext.xcall{value: msg.value}(
         _recipientDomain, // destination domain
         _recipient, // to
         address(token), // asset

--- a/contracts/claim/abstract/CrosschainMerkleDistributor.sol
+++ b/contracts/claim/abstract/CrosschainMerkleDistributor.sol
@@ -77,6 +77,9 @@ abstract contract CrosschainMerkleDistributor is CrosschainDistributor, MerkleSe
     uint256 claimedAmount =  _executeClaim(beneficiary, totalAmount);
 
     // interactions
+    // NOTE: xReceive is *NOT* payable (Connext does not handle native assets). 
+    // Fees must be bumped after-the-fact for second-leg claims, or debited from the claim
+    // amount in a more advanced mechanism.
     _settleClaim(beneficiary, beneficiary, beneficiaryDomain, claimedAmount);
 
     return bytes('');
@@ -94,7 +97,7 @@ abstract contract CrosschainMerkleDistributor is CrosschainDistributor, MerkleSe
     address _beneficiary,
     uint256 _total,
     bytes32[] calldata _proof
-  ) external {
+  ) external payable {
     _verifyMembership(_getLeaf(_beneficiary, _total, domain), _proof);
     // effects
     uint256 claimedAmount = _executeClaim(_beneficiary, _total);
@@ -124,7 +127,7 @@ abstract contract CrosschainMerkleDistributor is CrosschainDistributor, MerkleSe
     uint256 _total,
     bytes calldata _signature,
     bytes32[] calldata _proof
-  ) external {
+  ) external payable {
     // Recover the signature by beneficiary
     bytes32 _signed = keccak256(
       abi.encodePacked(_recipient, _recipientDomain, _beneficiary, _beneficiaryDomain, _total)

--- a/contracts/mocks/ConnextMock.sol
+++ b/contracts/mocks/ConnextMock.sol
@@ -15,6 +15,7 @@ contract ConnextMock {
         uint256 slippage,
         bytes callData
     );
+    event NativeRelayerFeeIncluded(address indexed caller, uint256 amount);
     uint32 private _domain;
     constructor(uint32 domain_) {
         setDomain(domain_);
@@ -40,6 +41,11 @@ contract ConnextMock {
         // Transfer asset if needed
         if (_amount > 0) {
             IERC20(_asset).transferFrom(msg.sender, address(this), _amount);
+        }
+
+        // Emit relayer fee event for native asset
+        if (msg.value > 0) {
+            emit NativeRelayerFeeIncluded(msg.sender, msg.value);
         }
         
         // Emit event + return identifier

--- a/test/distributor/CrosschainTrancheVestingMerkle.test.ts
+++ b/test/distributor/CrosschainTrancheVestingMerkle.test.ts
@@ -36,6 +36,11 @@ let tranches: Tranche[]
 // largest possible delay for the distributor using a fair queue
 const maxDelayTime = 1000n
 
+// domains for crosschain claims
+const SOURCE_DOMAIN = 1735353714;
+const DESTINATION_DOMAIN = 2;
+
+
 type Config = {
   total: bigint
   uri: string
@@ -57,8 +62,8 @@ type Config = {
 
 // distribute a million tokens in total
 const config: Config = {
-  // 7500 tokens
-  total: 7500000000000000000000n,
+  // 8500 tokens
+  total: 8500000000000000000000n,
   // any string will work for these unit tests - the uri is not used on-chain
   uri: 'https://example.com',
   // 2x, denominated in fractionDenominator of 1e4 (basis points)
@@ -166,10 +171,10 @@ describe("CrosschainTrancheVestingMerkle", function () {
 
     ConnextFactory = await ethers.getContractFactory("ConnextMock", deployer);
     connextMockSource = await ConnextFactory.deploy(
-      1735353714 // source domain
+      SOURCE_DOMAIN
     );
     connextMockDestination = await ConnextFactory.deploy(
-      2 // desination domain
+      DESTINATION_DOMAIN
     );
 
     // 50% of tokens should be vested
@@ -256,15 +261,17 @@ describe("CrosschainTrancheVestingMerkle", function () {
     expect((await distributor.getFractionDenominator()).toBigInt()).toEqual(10000n)
   })
 
-  it("Can claim via EOA signature", async () => {
+  it.only("Can claim via EOA signature", async () => {
     const user = eligible1
+    const relayerFee = ethers.utils.parseEther('0.1')
 
     const [beneficiary, amount, domain] = config.proof.claims[user.address.toLowerCase()].data.map(d => d.value)
     const proof = config.proof.claims[user.address.toLowerCase()].proof
+    const recipientDomain = domain === DESTINATION_DOMAIN.toString() ? SOURCE_DOMAIN : DESTINATION_DOMAIN;
 
     const txData = [
       { name: "recipient", type: "address", value: user.address },
-      { name: "recipientDomain", type: "uint32", value: domain },
+      { name: "recipientDomain", type: "uint32", value: recipientDomain },
       { name: "beneficiary", type: "address", value: user.address },
       { name: "beneficiaryDomain", type: "uint32", value: domain },
       { name: "amount", type: "uint256", value: amount }
@@ -285,9 +292,15 @@ describe("CrosschainTrancheVestingMerkle", function () {
       proof
     )).rejects.toMatchObject({ message: expect.stringMatching(/!recovered/) })
 
-    let balance = await token.balanceOf(user.address)
-    expect(balance.toBigInt()).toEqual(0n)
-
+    // get initial balances
+    const getBalances = async () => {
+      return {
+        user: (await token.balanceOf(user.address)).toBigInt(),
+        distributor: (await token.balanceOf(distributor.address)).toBigInt(),
+        connext: (await token.balanceOf(connextMockSource.address)).toBigInt()
+      }
+    }
+    const initialBalances = await getBalances();
 
     // check that user can't claim with invalid proof
     const badProof = [
@@ -295,7 +308,7 @@ describe("CrosschainTrancheVestingMerkle", function () {
     ]
     await expect(distributor.connect(user).claimBySignature(
       user.address,
-      domain,
+      recipientDomain,
       user.address,
       domain,
       amount,
@@ -303,23 +316,48 @@ describe("CrosschainTrancheVestingMerkle", function () {
       badProof
     )).rejects.toMatchObject({ message: expect.stringMatching(/invalid proof/) })
 
-    balance = await token.balanceOf(user.address)
-    expect(balance.toBigInt()).toEqual(0n)
+    // verify no asset transfers
+    let balances = await getBalances();
+    expect(balances.user).toEqual(initialBalances.user)
+    expect(balances.distributor).toEqual(initialBalances.distributor)
+    expect(balances.connext).toEqual(initialBalances.connext)
 
-    await distributor.connect(user).claimBySignature(
+    const request = await distributor.connect(user).claimBySignature(
       user.address,
-      domain,
+      recipientDomain,
       user.address,
       domain,
       amount,
       signature,
-      proof
-    )
+      proof,
+      { value: relayerFee }
+    );
+    const receipt = await request.wait()
 
-    const now = BigInt(await time.latest());
+    // verify relayer fee event
+    const RELAYER_FEE_EVENT_SIG = 'NativeRelayerFeeIncluded(address,uint256)'
+    const feeEvent = receipt.events.find(e => e.topics[0] === connextMockSource.interface.getEventTopic(RELAYER_FEE_EVENT_SIG))
+    const decodedFee = connextMockDestination.interface.decodeEventLog(RELAYER_FEE_EVENT_SIG, feeEvent.data, feeEvent.topics);
+    expect(decodedFee.amount).toEqual(relayerFee);
+    expect(decodedFee.caller).toEqual(distributor.address);
 
-    balance = await token.balanceOf(user.address)
-    expect(balance.toBigInt()).toEqual(BigInt(amount) / 2n)
+    // verify xcall event
+    const XCALL_FEE_EVENT_SIG = 'XCalled(uint32,address,address,address,uint256,uint256,bytes)'
+    const event = receipt.events.find(e => e.topics[0] === connextMockSource.interface.getEventTopic(XCALL_FEE_EVENT_SIG))
+    const decoded = connextMockDestination.interface.decodeEventLog(XCALL_FEE_EVENT_SIG, event.data, event.topics);
+    expect(decoded.destination.toString()).toEqual(recipientDomain.toString());
+    expect(decoded.to).toEqual(user.address);
+    expect(decoded.asset).toEqual(token.address);
+    expect(decoded.delegate).toEqual(user.address);
+    expect(decoded.amount.toBigInt()).toEqual(BigInt(amount) / 2n);
+    expect(decoded.slippage.toString()).toEqual("0");
+    expect(decoded.callData).toEqual("0x");
+
+    // verify asset transfers (distributor -> connext)
+    balances = await getBalances();
+    expect(balances.user).toEqual(initialBalances.user)
+    expect(balances.distributor).toEqual(initialBalances.distributor - BigInt(amount) / 2n)
+    expect(balances.connext).toEqual(initialBalances.connext + BigInt(amount) / 2n)
 
     const distributionRecord = await distributor.getDistributionRecord(user.address)
 
@@ -330,7 +368,7 @@ describe("CrosschainTrancheVestingMerkle", function () {
     // check that user can't claim again
     await expect(distributor.connect(user).claimBySignature(
       user.address,
-      domain,
+      recipientDomain,
       user.address,
       domain,
       amount,
@@ -486,7 +524,7 @@ describe("CrosschainTrancheVestingMerkle", function () {
 
       // set the tranches of the distributor so that the user should be able to claim 100% of tokens 2 seconds in the future
       const now = BigInt(await time.latest());
-    
+
       await time.increase(delay);
 
       await distributorWithQueue.setTranches([
@@ -495,7 +533,7 @@ describe("CrosschainTrancheVestingMerkle", function () {
 
       const [, amount,] = config.proof.claims[user.address.toLowerCase()].data.map(d => d.value)
       const proof = config.proof.claims[user.address.toLowerCase()].proof
-  
+
       // verify the user cannot yet claim
       await expect(distributorWithQueue.claimByMerkleProof(
         user.address,

--- a/test/distributor/Satellite.test.ts
+++ b/test/distributor/Satellite.test.ts
@@ -146,7 +146,7 @@ describe("Satellite", function () {
 
   it("Metadata is correct", async () => {
     expect((await satellite.distributor()).toLowerCase()).toEqual(distributorAddress)
-    expect (await satellite.distributorDomain()).toEqual(distributorDomain)
+    expect(await satellite.distributorDomain()).toEqual(distributorDomain)
     expect(await satellite.domain()).toEqual(domain)
     expect(await satellite.connext()).toEqual(connext.address)
     expect(await satellite.getMerkleRoot()).toEqual(config.proof.merkleRoot)
@@ -165,8 +165,8 @@ describe("Satellite", function () {
     const transactionReceipt = await transactionData.wait()
     const iface = new ethers.utils.Interface(SatelliteDefinition.abi)
     const { logs } = transactionReceipt
-    const transferId = iface.parseLog(logs[1]).args[0]
-    
+    const transferId = iface.parseLog(logs[2]).args[0]
+
     expect(transferId).toMatch(/^0x[0-9a-f]{64}$/)
   })
 
@@ -179,13 +179,13 @@ describe("Satellite", function () {
     const transactionData = await satellite.connect(user).initiateClaim(
       amount,
       proof,
-      {value: 1000000000000000n}
+      { value: 1000000000000000n }
     )
     const transactionReceipt = await transactionData.wait()
     const iface = new ethers.utils.Interface(SatelliteDefinition.abi)
     const { logs } = transactionReceipt
     const transferId = iface.parseLog(logs[1]).args[0]
-    
+
     expect(transferId).toMatch(/^0x[0-9a-f]{64}$/)
   })
 
@@ -199,8 +199,8 @@ describe("Satellite", function () {
         domain, // <-- this is the same as the satellite domain
         config.proof.merkleRoot
       )
-  ).rejects.toMatchObject(
-    { message: expect.stringMatching(/same domain/) }
-  )
+    ).rejects.toMatchObject(
+      { message: expect.stringMatching(/same domain/) }
+    )
   })
 })

--- a/test/distributor/Satellite.test.ts
+++ b/test/distributor/Satellite.test.ts
@@ -165,7 +165,7 @@ describe("Satellite", function () {
     const transactionReceipt = await transactionData.wait()
     const iface = new ethers.utils.Interface(SatelliteDefinition.abi)
     const { logs } = transactionReceipt
-    const transferId = iface.parseLog(logs[2]).args[0]
+    const transferId = iface.parseLog(logs[1]).args[0]
 
     expect(transferId).toMatch(/^0x[0-9a-f]{64}$/)
   })
@@ -184,7 +184,7 @@ describe("Satellite", function () {
     const transactionReceipt = await transactionData.wait()
     const iface = new ethers.utils.Interface(SatelliteDefinition.abi)
     const { logs } = transactionReceipt
-    const transferId = iface.parseLog(logs[1]).args[0]
+    const transferId = iface.parseLog(logs[2]).args[0]
 
     expect(transferId).toMatch(/^0x[0-9a-f]{64}$/)
   })


### PR DESCRIPTION
Fixes https://github.com/sherlock-audit/2023-06-tokensoft-judging/issues/143

- Makes `_settleClaim` payable
- Ensures the claim paths that are *not* xReceive pass through fees
- Adds a note that a different, layered on top mechanism will be required for second leg xcall fees in future launches
- Adds native fee event to connext mock
- Updates the EOA claim test case and failing tests
